### PR TITLE
ci: Added support for multiplatform builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,12 @@ jobs:
     name: Build and publish Docker image tag ${{ github.event.client_payload.tag }}
     runs-on: ubuntu-latest
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -27,6 +33,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: VERSION=${{ github.event.client_payload.tag }}
           # Tag as latest and the `client_payload` version tag


### PR DESCRIPTION
This PR just adds a couple of actions to setup multiplaform `buildx` builds (see https://docs.docker.com/build/ci/github-actions/multi-platform/ for reference)

Should fix #2