### PR TITLE
Set NVIDIA_DRIVER_CAPABILITIES

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,4 +73,6 @@ ENV NO_CORS=
 # See: https://github.com/Stremio/server-docker/issues/7
 ENV CASTING_DISABLED=1
 
+ENV NVIDIA_DRIVER_CAPABILITIES=video
+
 ENTRYPOINT [ "node", "server.js" ]


### PR DESCRIPTION
Enable the `video` driver feature when running the container with the Nvidia runtime.

https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/1.10.0/user-guide.html#driver-capabilities