### PR TITLE
Abort build on server download error

### DIFF
--- a/download_server.sh
+++ b/download_server.sh
@@ -6,7 +6,7 @@ WGET=$( which wget )
 
 # Pick our optimal fetching program (curl, then wget, then install curl)
 if [[ -n ${CURL} ]]; then
-    FETCH="${CURL} -O"
+    FETCH="${CURL} --fail -O"
 elif [[ -n ${WGET} ]]; then
     FETCH="${WGET}"
 else
@@ -16,7 +16,7 @@ else
     echo "> Installing required dependencies."
     apt install --yes curl
 
-    FETCH="${CURL} -O"
+    FETCH="${CURL} --fail -O"
     echo
 fi
 


### PR DESCRIPTION
Following #37

Added -f falg to curl, according to doc:
--fail
(HTTP) Fail with error code 22 and with no response body output at all for HTTP transfers returning HTTP response codes at 400 or greater.

Wget does it already without any flags.

Tested with VERSION=master with both wget and curl, it exit with non 0 and abort docker build