### PR TITLE
Fix: bogus bash arg to node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,11 @@ LABEL com.stremio.vendor="Smart Code Ltd."
 LABEL version=${VERSION}
 LABEL description="Stremio's streaming Server"
 
-SHELL ["/bin/sh", "-c"]
-
-CMD ["bash"]
-
 WORKDIR /stremio
 
 # We require version <= 4.4.1
 # https://github.com/jellyfin/jellyfin-ffmpeg/releases/tag/v4.4.1-4
 ARG JELLYFIN_VERSION=4.4.1-4
-
-# SHELL ["/bin/bash", "-c"]
 
 # COPY qemu-arm-static /usr/bin/qemu-arm-static
 


### PR DESCRIPTION
Since entrypoint is set, CMD has no intended effect. 

In fact, it's passed to node program, which ignores it:

```
# docker-compose exec stremio bash
root@64f0fbd0f863# ps axwuf
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root          17  0.0  0.0   3864  2980 pts/0    Ss   22:44   0:00 bash
root          59  0.0  0.0   5380  2376 pts/0    R+   22:45   0:00  \_ ps axwuf
root           1  0.3  0.3 638320 59636 ?        Ssl  22:44   0:00 node server.js bash
```